### PR TITLE
Add parameter fitting scripts for Steer Input Delay Model

### DIFF
--- a/ros/src/computing/planning/motion/packages/waypoint_follower/nodes/wf_simulator/README.md
+++ b/ros/src/computing/planning/motion/packages/waypoint_follower/nodes/wf_simulator/README.md
@@ -1,0 +1,28 @@
+# fitParamDelayInputModel.py scripts
+## How to use
+```
+python fitParamDelayInputModel.py --bag_file [bagfile] (--cutoff_time [cutoff_time] --cutoff_freq [cutoff_freq] --min_delay [min_delay] --max_delay [max_delay] --delay_incr [delay_incr]) 
+# in round brakets is optional arguments
+python fitParamDelayInputModel.py --help # for more information
+```
+
+## Requirements python packages:
+* numpy
+* pandas
+
+## Required topics
+* autoware_msgs::VehicleCmd /vehicle_cmd: assuming
+  * vehicle_cmd/ctrl_cmd/steering_angle is the steering angle input [rad]
+  * vehicle_cmd/ctrl_cmd/linear_velocity is the vehicle velocity input [m/s]
+* autoware_msgs::VehicleStatus /vehicle_status : assuming
+  * vehicle_status/angle is the measured steering angle [rad]
+  * vehicle_status/speed is the measured vehicle speed [km/h]
+
+## Description 
+* Paramter fitting for Input Delay Model (First Order System with Dead Time) with rosbag file input
+* Arguments explaining:
+  * CUTOFF_TIME: Cutoff time[sec]. Rosbag file often was start recording before autoware was run. Time before autoware was run should be cut off. This script will only consider data from t=cutoff_time to the end of the bag file (default is 1.0)
+  * CUTOFF_FREQ: Cutoff freq for low-pass filter[Hz], negative value will disable low-pass filter (default is 0.1)
+  * MIN_DELAY: Min value for searching delay loop (default is 0.1)
+  * MAX_DELAY: Max value for searching delay loop (default is 1.0)
+  * DELAY_INCR: Step value for searching delay loop (default is 0.01)

--- a/ros/src/computing/planning/motion/packages/waypoint_follower/nodes/wf_simulator/fitParamDelayInputModel.py
+++ b/ros/src/computing/planning/motion/packages/waypoint_follower/nodes/wf_simulator/fitParamDelayInputModel.py
@@ -100,10 +100,13 @@ def getFittingParam(cmd_data, act_data, speed_type = False):
     tau_opt = -1
     for delay in delays:
         tau, error = getFittingTimeConstantParam(cmd_data, act_data, delay, speed_type=speed_type)
-        if error < error_min:
-            error_min = error
-            delay_opt = delay
-            tau_opt = tau
+        if tau > 0:
+            if error < error_min:
+                error_min = error
+                delay_opt = delay
+                tau_opt = tau
+        else:
+            break
     return tau_opt, delay_opt, error_min
 
 if __name__ == '__main__':

--- a/ros/src/computing/planning/motion/packages/waypoint_follower/nodes/wf_simulator/fitParamDelayInputModel.py
+++ b/ros/src/computing/planning/motion/packages/waypoint_follower/nodes/wf_simulator/fitParamDelayInputModel.py
@@ -1,0 +1,68 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+import numpy as np
+import argparse
+import pandas as pd
+
+FREQ_SAMPLE = 0.001
+
+def getActValue(path):
+    # Read data
+    df = pd.read_csv(path, sep=' ')
+    tm = np.array(list(df['%time'])) * 1e-9
+    val = np.array(list(df['field']))
+    # Calc differential
+    dval = (val[2:] - val[:-2]) / (tm[2:] - tm[:-2])
+    return tm[1:-1], val[1:-1], dval
+
+def getCmdValueWithDelay(path, delay):
+    # Read data
+    df = pd.read_csv(path, sep=' ')
+    tm = np.array(list(df['%time'])) * 1e-9
+    val = np.array(list(df['field']))
+    return tm + delay, val
+
+def getLinearInterpolate(_tm, _val, _index, ti):
+    tmp_t = _tm[_index]
+    tmp_nextt = _tm[_index + 1]
+    tmp_val = _val[_index]
+    tmp_nextval = _val[_index + 1]
+    val_i = tmp_val + (tmp_nextval - tmp_val) / (tmp_nextt - tmp_t) * (ti - tmp_t)
+    return val_i
+
+def getFittingParam(args):
+    tm_cmd, cmd_delay = getCmdValueWithDelay(args.cmd_log, 0)
+    tm_act, act, dact = getActValue(args.act_log)
+    _t_min = max(tm_cmd[0], tm_act[0])
+    _t_max = min(tm_cmd[-1], tm_act[-1])
+    tm_cmd = tm_cmd - _t_min
+    tm_act = tm_act - _t_min
+    MAX_CNT = int((_t_max - _t_min) / FREQ_SAMPLE)
+    dact_samp = [None] * MAX_CNT
+    diff_actcmd_samp = [None] * MAX_CNT
+    ind_cmd = 0
+    ind_act = 0
+    for ind in range(MAX_CNT):
+        ti = ind * FREQ_SAMPLE
+        while (tm_cmd[ind_cmd + 1] < ti):
+            ind_cmd += 1
+        cmd_delay_i = getLinearInterpolate(tm_cmd, cmd_delay, ind_cmd, ti)
+        while (tm_act[ind_act + 1] < ti):
+            ind_act += 1
+        act_i = getLinearInterpolate(tm_act, act, ind_act, ti)
+        dact_i = getLinearInterpolate(tm_act, dact, ind_act, ti)
+        dact_samp[ind] = dact_i
+        diff_actcmd_samp[ind] = act_i - cmd_delay_i
+    dact_samp = np.array(dact_samp).reshape(1,-1)
+    diff_actcmd_samp = np.array(diff_actcmd_samp).reshape(1,-1)
+    tau = -np.dot(diff_actcmd_samp, np.linalg.pinv(dact_samp))[0,0]
+    return tau
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser(description='Paramter fitting for Input Delay Model (First Order System with Dead Time)')
+    parser.add_argument('--cmd_log', '-c', required=True, help='Vehicle command log file')
+    parser.add_argument('--act_log', '-a', required=True, help='Vehicle actual status log file')
+    args = parser.parse_args()
+    tau = getFittingParam(args)
+    print tau

--- a/ros/src/computing/planning/motion/packages/waypoint_follower/nodes/wf_simulator/fitParamDelayInputModel.py
+++ b/ros/src/computing/planning/motion/packages/waypoint_follower/nodes/wf_simulator/fitParamDelayInputModel.py
@@ -6,10 +6,9 @@ import argparse
 import pandas as pd
 
 FREQ_SAMPLE = 0.001
+CUTOFF_TIME = 15.0
 
-def getActValue(path, speed_type):
-    # Read data
-    df = pd.read_csv(path, sep=' ')
+def getActValue(df, speed_type):
     tm = np.array(list(df['%time'])) * 1e-9
     # Unit Conversion
     if speed_type:
@@ -20,9 +19,7 @@ def getActValue(path, speed_type):
     dval = (val[2:] - val[:-2]) / (tm[2:] - tm[:-2])
     return tm[1:-1], val[1:-1], dval
 
-def getCmdValueWithDelay(path, delay):
-    # Read data
-    df = pd.read_csv(path, sep=' ')
+def getCmdValueWithDelay(df, delay):
     tm = np.array(list(df['%time'])) * 1e-9
     val = np.array(list(df['field']))
     return tm + delay, val
@@ -35,20 +32,21 @@ def getLinearInterpolate(_tm, _val, _index, ti):
     val_i = tmp_val + (tmp_nextval - tmp_val) / (tmp_nextt - tmp_t) * (ti - tmp_t)
     return val_i
 
-def getFittingTimeConstantParam(cmd_log, act_log, delay, speed_type = False):
-    tm_cmd, cmd_delay = getCmdValueWithDelay(cmd_log, delay)
-    tm_act, act, dact = getActValue(act_log, speed_type)
+def getFittingTimeConstantParam(cmd_data, act_data, \
+                                delay, speed_type = False):
+    tm_cmd, cmd_delay = getCmdValueWithDelay(cmd_data, delay)
+    tm_act, act, dact = getActValue(act_data, speed_type)
     _t_min = max(tm_cmd[0], tm_act[0])
     _t_max = min(tm_cmd[-1], tm_act[-1])
     tm_cmd = tm_cmd - _t_min
     tm_act = tm_act - _t_min
-    MAX_CNT = int((_t_max - _t_min) / FREQ_SAMPLE)
+    MAX_CNT = int((_t_max - _t_min - CUTOFF_TIME) / FREQ_SAMPLE)
     dact_samp = [None] * MAX_CNT
     diff_actcmd_samp = [None] * MAX_CNT
     ind_cmd = 0
     ind_act = 0
     for ind in range(MAX_CNT):
-        ti = ind * FREQ_SAMPLE
+        ti = ind * FREQ_SAMPLE + CUTOFF_TIME
         while (tm_cmd[ind_cmd + 1] < ti):
             ind_cmd += 1
         cmd_delay_i = getLinearInterpolate(tm_cmd, cmd_delay, ind_cmd, ti)
@@ -68,14 +66,14 @@ MIN_DELAY = 0.0
 MAX_DELAY = 2.0
 DELAY_INCR = 0.1
 
-def getFittingParam(cmd_log, act_log, speed_type = False):
+def getFittingParam(cmd_data, act_data, speed_type = False):
     delay_range = int((MAX_DELAY - MIN_DELAY) / DELAY_INCR)
     delays = [MIN_DELAY + i * DELAY_INCR for i in range(delay_range + 1)]
     error_min = 1.0e10
     delay_opt = -1
     tau_opt = -1
     for delay in delays:
-        tau, error = getFittingTimeConstantParam(cmd_log, act_log, delay, speed_type=speed_type)
+        tau, error = getFittingTimeConstantParam(cmd_data, act_data, delay, speed_type=speed_type)
         if error < error_min:
             error_min = error
             delay_opt = delay
@@ -83,14 +81,17 @@ def getFittingParam(cmd_log, act_log, speed_type = False):
     return tau_opt, delay_opt, error_min
 
 if __name__ == '__main__':
-    parser = argparse.ArgumentParser(description='Paramter fitting for Input Delay Model (First Order System with Dead Time)')
-    parser.add_argument('--cmd_log', '-c', required=True, help='Vehicle command log file')
-    parser.add_argument('--act_log', '-a', required=True, help='Vehicle actual status log file')
-    parser.add_argument('--speed_type', '-s', choices=['True', 'False'], \
-                        default='False', help='Type speed or not: Steering Angle = False, velocity = True')
-    args = parser.parse_args()
-    if args.speed_type == 'True':
-        tau_opt, delay_opt, error = getFittingParam(args.cmd_log, args.act_log, speed_type=True)
-    else:
-        tau_opt, delay_opt, error = getFittingParam(args.cmd_log, args.act_log, speed_type=False)
-    print tau_opt, delay_opt, error
+    steer_cmd_log = 'vehicle_test_20190218-164427.cmd_steering_angle'
+    steer_act_log = 'vehicle_test_20190218-164427.vehicle_status_angle'
+    vel_cmd_log = 'vehicle_test_20190218-164427.cmd_linear_velocity'
+    vel_act_log = 'vehicle_test_20190218-164427.vehicle_status_speed'
+    steer_cmd_data = pd.read_csv(steer_cmd_log, sep=' ')
+    steer_act_data = pd.read_csv(steer_act_log, sep=' ')
+    vel_cmd_data = pd.read_csv(vel_cmd_log, sep=' ')
+    vel_act_data = pd.read_csv(vel_act_log, sep=' ')
+    tau_opt, delay_opt, error = getFittingParam(steer_cmd_data, \
+                                                steer_act_data, speed_type=False)
+    print ('Steer angle: tau_opt = %2.4f, delay_opt = %2.4f, error = %2.4e' %(tau_opt, delay_opt, error))
+    tau_opt, delay_opt, error = getFittingParam(vel_cmd_data, \
+                                                vel_act_data, speed_type=True)
+    print ('Velocity:    tau_opt = %2.4f, delay_opt = %2.4f, error = %2.4e' %(tau_opt, delay_opt, error))

--- a/ros/src/computing/planning/motion/packages/waypoint_follower/nodes/wf_simulator/fitParamDelayInputModel.py
+++ b/ros/src/computing/planning/motion/packages/waypoint_follower/nodes/wf_simulator/fitParamDelayInputModel.py
@@ -3,10 +3,15 @@
 
 import numpy as np
 import argparse
-import pandas as pd
 import subprocess
+import sys
 from os import getcwd
 from os.path import dirname, basename, splitext, join, exists
+try:
+    import pandas as pd
+except ImportError:
+    print ('Please install pandas. See http://pandas.pydata.org/pandas-docs/stable/')
+    sys.exit(1)
 
 FREQ_SAMPLE = 0.001
 CUTOFF_TIME = 15.0
@@ -20,12 +25,12 @@ def rel2abs(path):
 def rosbag_to_csv(path, topic_name):
     name = splitext(basename(path))[0]
     suffix = topic_name.replace('/', '-')
-    output_path = join(dirname(path), name + "_" + suffix + ".csv")
+    output_path = join(dirname(path), name + '_' + suffix + '.csv')
     if exists(output_path):
         return output_path
     else:
         command = "rostopic echo -b {0} -p /{1} | sed -e 's/,/ /g' > {2}".format(path, topic_name, output_path)
-        print command
+        print (command)
         subprocess.check_call(command, shell=True)
         return output_path
 
@@ -103,7 +108,7 @@ def getFittingParam(cmd_data, act_data, speed_type = False):
 
 if __name__ == '__main__':
     topics = [ 'vehicle_cmd/ctrl_cmd/steering_angle', 'vehicle_status/angle', \
-             'vehicle_cmd/ctrl_cmd/linear_velocity', 'vehicle_status/speed']
+               'vehicle_cmd/ctrl_cmd/linear_velocity', 'vehicle_status/speed']
     pd_data = [None] * len(topics)
     parser = argparse.ArgumentParser(description='Paramter fitting for Input Delay Model (First Order System with Dead Time) with rosbag file input')
     parser.add_argument('--bag_file', '-b', required=True, type=str, help='rosbag file', metavar='file')


### PR DESCRIPTION
一次遅れ系＋無駄時間のパラメータ推定スクリプト + READMEを追加しました．

## How to use
```
python fitParamDelayInputModel.py --bag_file [bagfile] (--cutoff_time [cutoff_time] --cutoff_freq [cutoff_freq] --min_delay [min_delay] --max_delay [max_delay] --delay_incr [delay_incr])
# in round brakets is optional arguments
python fitParamDelayInputModel.py --help # for more information
```

## 実行例
```
$ python fitParamDelayInputModel.py --bag_file autoware-2019052317
0829_lowsize.bag --cutoff_time 12.0 --cutoff_freq 0.1 --min_delay 0.1 --max_delay 1.0 --delay_incr 0.01
Steer angle: tau_opt = 0.1142, delay_opt = 0.1000, error = 9.6807e-06
Velocity   : tau_opt = 0.6197, delay_opt = 0.2500, error = 5.8989e-04
```
詳細説明はREADME参照