### PR TITLE
Fix nan value when Time Constant = 0, Segmentation fault when Delay Constant = 0

### DIFF
--- a/ros/src/computing/planning/motion/packages/waypoint_follower/nodes/wf_simulator/wf_simulator_core.cpp
+++ b/ros/src/computing/planning/motion/packages/waypoint_follower/nodes/wf_simulator/wf_simulator_core.cpp
@@ -55,10 +55,10 @@ WFSimulator::WFSimulator() : nh_(""), pnh_("~"), is_initialized_(false), is_prev
     pnh_.param("accel_rate", accel_rate, double(1.0));
     pnh_.param("angvel_rate", angvel_rate, double(1.0));
     pnh_.param("steer_vel", steer_vel, double(0.3));
-    pnh_.param("vel_time_delay", vel_time_delay, double(0.3));
-    pnh_.param("vel_time_constant", vel_time_constant, double(0.1));
-    pnh_.param("steer_time_delay", steer_time_delay, double(1.0));
-    pnh_.param("steer_time_constant", steer_time_constant, double(0.5));
+    pnh_.param("vel_time_delay", vel_time_delay, double(0.25));
+    pnh_.param("vel_time_constant", vel_time_constant, double(0.6197));
+    pnh_.param("steer_time_delay", steer_time_delay, double(0.1));
+    pnh_.param("steer_time_constant", steer_time_constant, double(0.1142));
     pnh_.param("angvel_time_delay", angvel_time_delay, double(0.2));
     pnh_.param("angvel_time_constant", angvel_time_constant, double(0.5));
     const double dt = 1.0 / loop_rate_;


### PR DESCRIPTION
* 変更内容のまとめ：
  * Time Constant = 0， Delay Constant = 0の時を対応した
  * DELAY_STEERモードのデフォルトパラメーターを修正する（パラメーターフィティングスクリプト https://github.com/TakaHoribe/Autoware/pull/8 の実行結果）
* 変更前：
```
$ rosrun waypoint_follower wf_simulator _vehicle_model_type:=DELAY_STEER _steer_time_delay:=0 _steer_time_constant:=0.1142 
[ INFO] [1561436391.853608817]: initialize_source : Origin
Segmentation fault (コアダンプ)

$ rosrun waypoint_follower wf_simulator _vehicle_model_type:=DELAY_STEER _steer_time_delay:=0.1 _steer_time_constant:=0
[ INFO] [1561436515.002306715]: initialize_source : Origin
Error:   TF_NAN_INPUT: Ignoring transform for child_frame_id "sim_base_link" from authority "unknown_publisher" because of a nan value in the transform (-nan -nan 0.000000) (-nan -nan -nan -nan)
         at line 244 in /tmp/binarydeb/ros-kinetic-tf2-0.5.20/src/buffer_core.cpp
Error:   TF_DENORMALIZED_QUATERNION: Ignoring transform for child_frame_id "sim_base_link" from authority "unknown_publisher" because of an invalid quaternion in the transform (-nan -nan -nan -nan)
         at line 257 in /tmp/binarydeb/ros-kinetic-tf2-0.5.20/src/buffer_core.cpp
        [...] 
```
* 原因：
  * delay constantが0の時，空のqueueからpop_frontするので，コアダンプになった．
ｰ> 対策：push_back()とpop_front()する順番を逆にする
  * time constantが0の時，time constantのが逆数をかけるのでnanの値になってしまった
ｰ> 対策：MIN_TIME_CONSTANTを設定して，MIN_TIME_CONSTANTより小さかったら，MIN_TIME_CONSTANTの値にする + 値変更したWARNINGが出す（現在MIN_TIME_CONSTANT = 0.01にする）
* 変更後：
```
$ rosrun waypoint_follower wf_simulator _vehicle_model_type:=DELAY_STEER _steer_time_delay:=
0 _steer_time_constant:=0.1142 
[ INFO] [1561437863.048058649]: initialize_source : Origin

$ rosrun waypoint_follower wf_simulator _vehicle_model_type:=DELAY_STEER _steer_time_delay:=
0.1 _steer_time_constant:=0
[ WARN] [1561437901.113470683]: Settings steer_time_constant is too small, replace it by 0.010000
[ INFO] [1561437901.114154474]: initialize_source : Origin
```